### PR TITLE
Add standard-app-packages to package dependencies Fix #4

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,5 +3,6 @@ Package.describe({
 });
 
 Package.on_use(function (api, where) {
+  api.use('standard-app-packages');
   api.add_files('paginated_subscription.js', 'client');
 });


### PR DESCRIPTION
Needed when using pagination package in private/other packages
