### PR TITLE
added onready callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ This package makes available a single function `Meteor.subscribeWithPagination`.
 var handle = Meteor.subscribeWithPagination('posts', 10);
 ```
 
-The arguments are as usual to `Meteor.subscribe`, with two exceptions:
+The arguments are as usual to `Meteor.subscribe`, with an exception:
 
 1. The last argument must be a number, indicating the number of documents per page.
-2. There's no support for a `onReady` callback, see TODO below.
+This can be followed by callback functions in style of `Meteor.subscribe`.
 
 The paginated subscription expects you to have a publication setup, as normal, which expects as a final argument the *current* number of documents to display (which will be incremented, in a infinite scroll fashion):
 
@@ -45,8 +45,7 @@ The first three functions are reactive and thus can be used to correctly display
 
 Contributions are heavily encouraged. The obvious things to fix are:
 
-1. Allow an `onReady` callback
-2. Do actual "pagination" rather than "infinite scroll" -- i.e. have an option to pass around an offset as well as limit.
-3. Tests, tests, tests
+1. Do actual "pagination" rather than "infinite scroll" -- i.e. have an option to pass around an offset as well as limit.
+2. Tests, tests, tests
 
 Please contact me if you want to have a go at these and I'll be happy to help in what ways I can.

--- a/paginated_subscription.js
+++ b/paginated_subscription.js
@@ -41,10 +41,16 @@ PaginatedSubscriptionHandle.prototype.reset = function() {
 }
 
 
-// XXX: deal with last argument being a callback
 Meteor.subscribeWithPagination = function (/*name, arguments, perPage */) {
   var args = Array.prototype.slice.call(arguments, 0);
-  var perPage = args.pop();
+  var lastArg = args.pop();
+  var perPage, cb = null;
+  if (_.isFunction(lastArg) || _.isObject(lastArg)) {
+    cb = lastArg; 
+    perPage = args.pop();
+  } else {
+    perPage = lastArg;
+  }
   
   var handle = new PaginatedSubscriptionHandle(perPage);
   
@@ -52,8 +58,8 @@ Meteor.subscribeWithPagination = function (/*name, arguments, perPage */) {
     var ourArgs = _.map(args, function(arg) {
       return _.isFunction(arg) ? arg() : arg;
     });
-    
-    var subHandle = Meteor.subscribe.apply(this, ourArgs.concat([handle.limit()]));
+   
+    var subHandle = Meteor.subscribe.apply(this, ourArgs.concat([handle.limit(), cb]));
     
     // whenever the sub becomes ready, we are done. This may happen right away
     // if we are re-subscribing to an already ready subscription.


### PR DESCRIPTION
Added optional argument to `Meteor. subscribeWithPagination`.  Does not break any invocations.  This argument works just like the `callbacks` argument in `Meteor.subscribe` and either an object or function is expected.  The `perPage` argument is still required.

No tests yet.
